### PR TITLE
Detect default branch from GitHub

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,8 +22,6 @@ jobs:
           ~/.stack/
           .stack-work/
         key: ${{ runner.os }}-${{ hashFiles('stack.yaml.lock') }}
-    - name: Debugging with tmate
-      uses: mxschmitt/action-tmate@v3
     - name: stack install
       run: stack install
     - name: Output Stack local bin directory

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,6 @@ jobs:
       uses: actions/cache@v2
       with:
         path: |
-          ~/.stack/
           .stack-work/
         key: ${{ runner.os }}-${{ hashFiles('stack.yaml.lock') }}
     - name: stack install

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,6 +22,8 @@ jobs:
           ~/.stack/
           .stack-work/
         key: ${{ runner.os }}-${{ hashFiles('stack.yaml.lock') }}
+    - name: Debugging with tmate
+      uses: mxschmitt/action-tmate@v3
     - name: stack install
       run: stack install
     - name: Output Stack local bin directory

--- a/src/Remote.hs
+++ b/src/Remote.hs
@@ -44,6 +44,10 @@ createPullRequest :: Remote -> PR.PullRequest -> IO PR.PullRequest
 createPullRequest (GitHub token)    = GH.createPullRequest token
 createPullRequest (Bitbucket token) = BB.createPullRequest token
 
+defaultBranch :: Remote -> IO (Maybe Branch)
+defaultBranch (GitHub token) = GH.getDefaultBranch token
+defaultBranch (Bitbucket _) = return Nothing
+
 open :: Remote -> Maybe String -> IO ()
 open remote file = do
   maybeRi <- repoInfoFromRepo


### PR DESCRIPTION
Implemented No. 2 from #42.

> Use the default branch from GitHub/Bitbucket.