### PR TITLE
Determine base branch using remote branches

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -7,8 +7,9 @@ import           CredentialUtils       (Credentials (..), credFilePath,
                                         readCredential, writeCredential)
 import           Data.List             (isInfixOf, isPrefixOf)
 import           Data.Maybe            (fromMaybe, listToMaybe)
-import           GitUtils              (Branch, getCurrentBranch, getRemoteUrl)
-import           ListUtils             (formatEachAndJoin)
+import           GitUtils              (Branch, getCurrentBranch, getRemoteUrl,
+                                        listRemoteBranches)
+import           ListUtils             (firstMatching, formatEachAndJoin)
 import           Remote                (authenticate, createIssue,
                                         createPullRequest, defaultBranch, getIssue,
                                         getPullRequest, listIssues,
@@ -142,6 +143,15 @@ handlePullRequest remote params
   | otherwise = printError $ "Command " ++ ssc ++ " not supported"
     where ssc = head params
           rest = tail params
+
+determineBaseBranch :: Remote -> IO Branch
+determineBaseBranch remote = do
+  remoteBase <- defaultBranch remote
+  case remoteBase of
+    Just base -> return base
+    Nothing -> do
+      remoteBranches <- listRemoteBranches
+      return $ fromMaybe "master" (firstMatching remoteBranches ["develop", "main", "master"])
 
 handleAuth :: Remote -> Credentials -> FilePath -> IO ()
 handleAuth remote creds credFP = do

--- a/src/GitUtils.hs
+++ b/src/GitUtils.hs
@@ -5,10 +5,13 @@ module GitUtils
   , repoInfoFromRepo
   , getRemoteUrl
   , getCurrentBranch
+  , listBranches
+  , listRemotes
   ) where
 
 import           Data.Git            (refNameRaw)
-import           Data.Git.Repository (configGet, headGet)
+import           Data.Git.Named      (looseRemotesList)
+import           Data.Git.Repository (branchList, configGet, headGet)
 import           Data.Git.Storage    (findRepoMaybe, openRepo, withCurrentRepo)
 import           Data.List           (isPrefixOf, isSuffixOf)
 import           Data.String.Utils   (replace)
@@ -59,3 +62,18 @@ urlToRepoInfo :: String -> Maybe RepoInfo
 urlToRepoInfo url = do
   uri <- parseURI $ toFullSshUrl url
   return $ (segmentsToRepoInfo . pathSegments) uri
+
+listBranches = do
+  maybePath <- findRepoMaybe
+  case maybePath of
+    Just path -> do
+      repo <- openRepo path
+      branchList repo
+    Nothing   -> Prelude.error "aaaa"
+
+listRemotes = do
+  maybePath <- findRepoMaybe
+  case maybePath of
+    Just path -> do
+      looseRemotesList path
+    Nothing   -> Prelude.error "aaaa"

--- a/src/ListUtils.hs
+++ b/src/ListUtils.hs
@@ -1,11 +1,12 @@
 module ListUtils
   (
-    formatEachAndJoin,
-    nthOrDefault,
-    nthOrNothing
+    firstMatching
+  , formatEachAndJoin
+  , nthOrDefault
+  , nthOrNothing
   ) where
 
-import           Data.List  (intercalate)
+import           Data.List  (find, intercalate)
 import           Data.Maybe (fromMaybe)
 
 nthOrDefault :: [a] -> a -> Integer -> a
@@ -23,3 +24,7 @@ nthOrNothingInner (x: xs) index curIndex =
 
 formatEachAndJoin :: [a] -> (a -> String) -> String
 formatEachAndJoin list formatter = intercalate "\n" $ fmap formatter list
+
+firstMatching :: Eq a => [a] -> [a] -> Maybe a
+firstMatching items = find matches
+  where matches candidate = candidate `elem` items


### PR DESCRIPTION
This PR will use the remote branches as candidates for base branches assuming they are either "develop", "main" or "master".

Fixes #42