### PR TITLE
Upgrade to GHC 9.12.1 and Cabal 3.14.1.1

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,7 @@ jobs:
       - uses: haskell-actions/setup@v2
         id: setup
         with:
-          ghc-version: '9.10.1'
+          ghc-version: '9.12.1'
           cabal-version: '3.12.1.0'
       - name: Generate build plan
         run: cabal build all --dry-run

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,7 @@ jobs:
         id: setup
         with:
           ghc-version: '9.12.1'
-          cabal-version: '3.12.1.0'
+          cabal-version: '3.14.1.1'
       - name: Generate build plan
         run: cabal build all --dry-run
       - name: Restore cached dependencies

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,3 +1,8 @@
 # Changelog for gwcli-hs
 
 ## Unreleased changes
+
+## 0.9.6.0 -- 2025-03-09
+
+* Upgraded to GHC 9.12.1
+* Fixed ambiguous 'show' function references for GHC 9.12.1 compatibility

--- a/gwcli.cabal
+++ b/gwcli.cabal
@@ -1,7 +1,7 @@
 cabal-version: 2.4
 
 name:           gwcli
-version:        0.9.5.0
+version:        0.9.6.0
 description:    Please see the README on GitHub at <https://github.com/diskshima/gwcli-hs#readme>
 homepage:       https://github.com/diskshima/gwcli-hs
 bug-reports:    https://github.com/diskshima/gwcli-hs/issues

--- a/src/BitbucketApi.hs
+++ b/src/BitbucketApi.hs
@@ -67,11 +67,11 @@ urlFromPullRequest  = maybe "" BC.href . BC.html . BP.links
 
 responseToIssue :: Issue -> I.Issue
 responseToIssue i =
-  I.Issue (Just . show $ BI.id i) (BI.title i) Nothing (Just $ urlFromIssue i)
+  I.Issue (Just . P.show $ BI.id i) (BI.title i) Nothing (Just $ urlFromIssue i)
 
 responseToPullRequest :: PullRequest -> PR.PullRequest
 responseToPullRequest pr =
-  PR.PullRequest (Just . show $ BP.id pr) (BP.title pr)
+  PR.PullRequest (Just . P.show $ BP.id pr) (BP.title pr)
                  "" "" Nothing (Just htmlLink)
                    where htmlLink = urlFromPullRequest pr
 


### PR DESCRIPTION
# Upgrade to GHC 9.12.1 and Cabal 3.14.1.1

This PR upgrades the project to use GHC 9.12.1 and Cabal 3.14.1.1, which are the latest versions as of March 2025.

## Changes

### CI Configuration
- Updated GitHub Actions workflow to use GHC 9.12.1 (previously 9.10.1)
- Updated Cabal version to 3.14.1.1 (previously 3.12.1.0)

### Code Compatibility
- Fixed ambiguous show function references in BitbucketApi.hs
- Explicitly qualified with P.show to resolve conflicts between Prelude and Text.Lazy imports

## Testing
- Successfully built and tested locally with GHC 9.12.1 and Cabal 3.14.1.1
- Fixed all compile errors that occurred during the upgrade
- Verified that the application runs correctly by using the newly built binary

## Additional Notes
- A warning appears during the build about Cabal 3.12.1.0 not having explicit support for GHC 9.12.1, which is resolved by upgrading to Cabal 3.14.1.1