### PR TITLE
Restore short subcommands for improved CLI usability

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,12 @@
 # Changelog for gwcli-hs
 
+## 0.10.0.0 -- 2026-01-09
+
+* Added short command aliases for improved CLI usability:
+  - Top-level: `a` (auth), `b` (browse), `i` (issue), `pr` (pullrequest), `v` (version)
+  - Subcommands: `l` (list), `c` (create), `s` (show)
+* Restored convenience of short commands from the old GetOpt-based parser
+
 ## 0.9.9.0 -- 2025-10-12
 
 * Improved error messages when API calls fail with HTTP status codes and response details (#95)

--- a/gwcli.cabal
+++ b/gwcli.cabal
@@ -1,7 +1,7 @@
 cabal-version: 3.14
 
 name:           gwcli
-version:        0.9.9.0
+version:        0.10.0.0
 description:    Please see the README on GitHub at <https://github.com/diskshima/gwcli-hs#readme>
 homepage:       https://github.com/diskshima/gwcli-hs
 bug-reports:    https://github.com/diskshima/gwcli-hs/issues

--- a/src/CommandLineParser.hs
+++ b/src/CommandLineParser.hs
@@ -136,10 +136,16 @@ issueCommandParser :: Parser IssueCommand
 issueCommandParser = subparser
     ( command "list" (info (IssueList <$> issueListOptionsParser <**> helper)
         (progDesc "List issues. Use --all to show all issues."))
+   <> command "l" (info (IssueList <$> issueListOptionsParser <**> helper)
+        (progDesc "List issues (short form)"))
    <> command "create" (info (IssueCreate <$> issueCreateOptionsParser <**> helper)
         (progDesc "Create a new issue."))
+   <> command "c" (info (IssueCreate <$> issueCreateOptionsParser <**> helper)
+        (progDesc "Create a new issue (short form)"))
    <> command "show" (info (IssueShow <$> issueShowOptionsParser <**> helper)
         (progDesc "Show a specific issue by its number."))
+   <> command "s" (info (IssueShow <$> issueShowOptionsParser <**> helper)
+        (progDesc "Show a specific issue (short form)"))
     )
 
 -- Parsers for pull request actions
@@ -177,20 +183,31 @@ pullRequestCommandParser :: Parser PullRequestCommand
 pullRequestCommandParser = subparser
     ( command "list" (info (PullRequestList <$> pullRequestListOptionsParser <**> helper)
         (progDesc "List pull requests. Use --all to show all PRs."))
+   <> command "l" (info (PullRequestList <$> pullRequestListOptionsParser <**> helper)
+        (progDesc "List pull requests (short form)"))
    <> command "create" (info (PullRequestCreate <$> pullRequestCreateOptionsParser <**> helper)
         (progDesc "Create a new pull request."))
+   <> command "c" (info (PullRequestCreate <$> pullRequestCreateOptionsParser <**> helper)
+        (progDesc "Create a new pull request (short form)"))
    <> command "show" (info (PullRequestShow <$> pullRequestShowOptionsParser <**> helper)
         (progDesc "Show a specific pull request by its number."))
+   <> command "s" (info (PullRequestShow <$> pullRequestShowOptionsParser <**> helper)
+        (progDesc "Show a specific pull request (short form)"))
     )
 
 -- Combined command parser using subcommands
 commandParser :: Parser Command
 commandParser = subparser
     ( command "auth" (info (AuthCmd <$> authOptionsParser <**> helper) (progDesc "Authenticate with services"))
+   <> command "a" (info (AuthCmd <$> authOptionsParser <**> helper) (progDesc "Authenticate with services (short form)"))
    <> command "browse" (info (BrowseCmd <$> browseOptionsCliParser <**> helper) (progDesc "Open repository page in browser"))
+   <> command "b" (info (BrowseCmd <$> browseOptionsCliParser <**> helper) (progDesc "Open repository page in browser (short form)"))
    <> command "issue" (info (IssueCmd <$> issueCommandParser) (progDesc "Manage issues (list, create, show)"))
-   <> command "pullrequest" (info (PullRequestCmd <$> pullRequestCommandParser) (progDesc "Manage pull requests (list, create, show)")) -- Added
+   <> command "i" (info (IssueCmd <$> issueCommandParser) (progDesc "Manage issues (short form)"))
+   <> command "pullrequest" (info (PullRequestCmd <$> pullRequestCommandParser) (progDesc "Manage pull requests (list, create, show)"))
+   <> command "pr" (info (PullRequestCmd <$> pullRequestCommandParser) (progDesc "Manage pull requests (short form)"))
    <> command "version" (info (VersionCmd <$> versionOptionsParser <**> helper) (progDesc "Show version (same as --version flag)"))
+   <> command "v" (info (VersionCmd <$> versionOptionsParser <**> helper) (progDesc "Show version (short form)"))
     )
 
 -- Top-level parser for all arguments (GlobalOptions + Command)


### PR DESCRIPTION
Add command aliases to restore the short subcommand functionality
that was available in the old GetOpt-based parser. This change maintains
compatibility with the modern optparse-applicative library while
restoring the convenient short forms that users were accustomed to.

Changes:
- Top-level command aliases: a, b, i, pr, v
- Issue subcommand aliases: l, c, s
- PullRequest subcommand aliases: l, c, s

Examples:
- gwcli i l (equivalent to gwcli issue list)
- gwcli pr c (equivalent to gwcli pullrequest create)
- gwcli i s 123 (equivalent to gwcli issue show 123)